### PR TITLE
[Feat] create portal과 context로 modal 컴포넌트 생성 

### DIFF
--- a/src/components/common/Button/index.tsx
+++ b/src/components/common/Button/index.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 
 interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
-  size: 'small' | 'medium' | 'large';
+  size: 'small' | 'medium' | 'large' | 'fullWidth';
   variant: 'primary' | 'secondary-red' | 'secondary-blue' | 'disabled';
 }
 
@@ -13,7 +13,8 @@ export default function Button({ onClick, size, variant, disabled, ...rest }: Pr
         {
           'text-xs-rg h-8 w-[82px]': size === 'small',
           'text-md-bold h-[37px] w-27': size === 'medium',
-          'text-lg-bold h-12 w-full': size === 'large',
+          'text-md-bold h-12 w-30': size === 'large',
+          'text-lg-bold h-12 w-full': size === 'fullWidth',
         },
         {
           'bg-primary text-white': variant === 'primary',

--- a/src/components/common/Modal/DefaultModalFooter.tsx
+++ b/src/components/common/Modal/DefaultModalFooter.tsx
@@ -1,0 +1,16 @@
+import Button from '../Button';
+
+interface Props {
+  defaultFooterText: string;
+}
+export default function DefaultModalFooter({ defaultFooterText = '확인' }: Props) {
+  const modalClose = () => {
+    //모달 닫힘 구현
+  };
+
+  return (
+    <Button size="large" variant="primary" onClick={modalClose}>
+      {defaultFooterText}
+    </Button>
+  );
+}

--- a/src/components/common/Modal/ModalContainer.tsx
+++ b/src/components/common/Modal/ModalContainer.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import clsx from 'clsx';
+
+interface Props {
+  children: ReactNode;
+
+  className?: string;
+}
+export default function ModalContainer({ children, ...props }: Props) {
+  return (
+    <div
+      className={clsx(
+        'w-full min-w-[327px] rounded-lg bg-white px-7 py-7 md:w-full md:max-w-135',
+        props.className
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/Modal/ModalOverlay.tsx
+++ b/src/components/common/Modal/ModalOverlay.tsx
@@ -4,6 +4,7 @@ import { ReactNode, useEffect } from 'react';
 interface Props {
   children: ReactNode;
   className?: string;
+  onClick: () => void;
 }
 export default function ModalOverlay({ children, className, ...props }: Props) {
   useEffect(() => {

--- a/src/components/common/Modal/ModalOverlay.tsx
+++ b/src/components/common/Modal/ModalOverlay.tsx
@@ -6,10 +6,6 @@ interface Props {
   className?: string;
 }
 export default function ModalOverlay({ children, className, ...props }: Props) {
-  const handleClickModalOverlay = () => {
-    //바깥 영역 클릭시 닫힘 처리
-  };
-
   useEffect(() => {
     const originalStyle = window.getComputedStyle(document.body).overflow;
     document.body.style.overflow = 'hidden';
@@ -20,7 +16,6 @@ export default function ModalOverlay({ children, className, ...props }: Props) {
   }, []);
   return (
     <div
-      onClick={handleClickModalOverlay}
       className={clsx(
         'fixed inset-0 z-999 flex items-center justify-center bg-black/70',
         className

--- a/src/components/common/Modal/ModalOverlay.tsx
+++ b/src/components/common/Modal/ModalOverlay.tsx
@@ -1,0 +1,33 @@
+import clsx from 'clsx';
+import { ReactNode, useEffect } from 'react';
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+}
+export default function ModalOverlay({ children, className, ...props }: Props) {
+  const handleClickModalOverlay = () => {
+    //바깥 영역 클릭시 닫힘 처리
+  };
+
+  useEffect(() => {
+    const originalStyle = window.getComputedStyle(document.body).overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = originalStyle;
+    };
+  }, []);
+  return (
+    <div
+      onClick={handleClickModalOverlay}
+      className={clsx(
+        'fixed inset-0 z-999 flex items-center justify-center bg-black/70',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/common/Modal/core/ModalContext.tsx
+++ b/src/components/common/Modal/core/ModalContext.tsx
@@ -1,0 +1,15 @@
+import { createContext } from 'react';
+
+export interface ModalState {
+  [id: string]: { isOpen: boolean };
+}
+type ModalContextActions = {
+  openModal: (id: string) => void;
+  closeModal: (id: string) => void;
+  modals: ModalState;
+  checkIsModalOpen: (id: string) => boolean;
+};
+
+const ModalContext = createContext<ModalContextActions | null>(null);
+
+export default ModalContext;

--- a/src/components/common/Modal/core/ModalPortal.tsx
+++ b/src/components/common/Modal/core/ModalPortal.tsx
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import useModalContext from './useModalContext';
+
+interface ModalPortalProps {
+  children: React.ReactNode;
+  modalId: string;
+
+  containerId?: string;
+}
+
+export default function ModalPortal({
+  children,
+  modalId,
+  containerId = 'modal-root',
+}: ModalPortalProps) {
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const { checkIsModalOpen } = useModalContext();
+
+  useEffect(() => {
+    let el = document.getElementById(containerId);
+
+    if (!el) {
+      el = document.createElement('div');
+      el.id = containerId;
+      document.body.appendChild(el);
+    }
+
+    setContainer(el);
+  }, [containerId]);
+
+  if (!container || !checkIsModalOpen(modalId)) return null;
+
+  return createPortal(
+    typeof children === 'function' ? (children as () => React.ReactNode)() : children,
+    container
+  );
+}

--- a/src/components/common/Modal/core/ModalProvider.tsx
+++ b/src/components/common/Modal/core/ModalProvider.tsx
@@ -1,0 +1,33 @@
+import { useState, useCallback } from 'react';
+import ModalContext, { ModalState } from './ModalContext';
+
+export default function ModalProvider({ children }: { children: React.ReactNode }) {
+  const [modals, setModals] = useState<ModalState>({});
+
+  const openModal = (id: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [id]: { isOpen: true },
+    }));
+  };
+
+  const closeModal = (id: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [id]: { isOpen: false },
+    }));
+  };
+
+  const checkIsModalOpen = useCallback(
+    (id: string) => {
+      return modals[id]?.isOpen ?? false;
+    },
+    [modals]
+  );
+
+  return (
+    <ModalContext.Provider value={{ openModal, modals, closeModal, checkIsModalOpen }}>
+      {children}
+    </ModalContext.Provider>
+  );
+}

--- a/src/components/common/Modal/core/useModalContext.ts
+++ b/src/components/common/Modal/core/useModalContext.ts
@@ -1,0 +1,8 @@
+import { use } from 'react';
+import ModalContext from './ModalContext';
+
+export default function useModalContext() {
+  const ctx = use(ModalContext);
+  if (!ctx) throw new Error('useModal must be used within ModalProvider');
+  return ctx;
+}

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,9 +1,21 @@
+import { ReactNode } from 'react';
+import ModalContainer from './ModalContainer';
 import ModalOverlay from './ModalOverlay';
+import DefaultModalFooter from './DefaultModalFooter';
 
-export default function Modal() {
+interface Props {
+  children: ReactNode;
+
+  defaultFooterText?: string;
+  modalFooter?: ReactNode;
+}
+export default function Modal({ children, defaultFooterText = '확인', ...props }: Props) {
   return (
     <ModalOverlay>
-      <div></div>
+      <ModalContainer className="">
+        {children}
+        {props.modalFooter && <DefaultModalFooter defaultFooterText={defaultFooterText} />}
+      </ModalContainer>
     </ModalOverlay>
   );
 }

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -2,19 +2,27 @@ import { ReactNode } from 'react';
 import ModalContainer from './ModalContainer';
 import ModalOverlay from './ModalOverlay';
 import DefaultModalFooter from './DefaultModalFooter';
+import clsx from 'clsx';
+import useModalContext from './core/useModalContext';
 
 interface Props {
   children: ReactNode;
+  modalId: string;
 
+  modalContainerClassName?: string;
   defaultFooterText?: string;
   modalFooter?: ReactNode;
 }
-export default function Modal({ children, defaultFooterText = '확인', ...props }: Props) {
+export default function Modal({ modalId, defaultFooterText = '확인', ...props }: Props) {
+  const { closeModal } = useModalContext();
+
   return (
-    <ModalOverlay>
-      <ModalContainer className="">
-        {children}
-        {props.modalFooter && <DefaultModalFooter defaultFooterText={defaultFooterText} />}
+    <ModalOverlay onClick={() => closeModal(modalId)}>
+      <ModalContainer
+        className={clsx('flex flex-col items-center gap-8', props.modalContainerClassName)}
+      >
+        {props.children}
+        {!props.modalFooter && <DefaultModalFooter defaultFooterText={defaultFooterText} />}
       </ModalContainer>
     </ModalOverlay>
   );

--- a/src/components/common/Modal/index.tsx
+++ b/src/components/common/Modal/index.tsx
@@ -1,0 +1,9 @@
+import ModalOverlay from './ModalOverlay';
+
+export default function Modal() {
+  return (
+    <ModalOverlay>
+      <div></div>
+    </ModalOverlay>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
+import ModalProvider from './components/common/Modal/core/modalProvider.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
-  </StrictMode>,
-)
+    <ModalProvider>
+      <App />
+    </ModalProvider>
+  </StrictMode>
+);

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,7 +1,17 @@
+import Modal from '../../components/common/Modal';
+import ModalPortal from '../../components/common/Modal/core/modalPortal';
+import useModalContext from '../../components/common/Modal/core/useModalContext';
+
 export default function Home() {
+  const { openModal } = useModalContext();
   return (
     <div>
-      <div className="text-red40">페이지</div>
+      <div onClick={() => openModal('test')}>id로 열림 버튼</div>
+      <ModalPortal modalId="test">
+        <Modal modalId="test">
+          <div>컨텐츠</div>
+        </Modal>
+      </ModalPortal>
     </div>
   );
 }


### PR DESCRIPTION
## 🔎 작업 사항 
* create portal과 context로 스케일러블한 모달 구현 
* modal footer를 prop으로 전달하지 않으면, default modal footer가 렌더링 됨 (닫기 기능) 
* default modal footer 사용시, text를 넘겨주어야 함 
* 모달 컨텐츠에 종류에 따라 모달 아이콘 (컨텐츠내의 아이콘) 등을 추가할수 있게 ui 구조를 세분화 할수 있는 가능성을 열어둠

## 📷 스크린샷
<img width="1022" alt="스크린샷 2025-05-11 오후 11 46 55" src="https://github.com/user-attachments/assets/a55781e8-eede-43fd-907a-96ca83eeedeb" />

## ❗️ 전달 사항

.

## ➕ 관련 이슈 
#3 
.
